### PR TITLE
Install SuiteSparse header files during CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,6 +24,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install & test
       run: |
+        sudo apt install libsuitesparse-dev
         npm i
         npm test
     - name: Coveralls


### PR DESCRIPTION
Fix a bug for Python 3.9 where newer versions of cvxopt do not include
a SuiteSparse header file necessary for compilation. Install the
developer headers of SuiteSparse during CI setup.

This will get CI working again.

See: https://github.com/cvxopt/cvxopt/issues/78